### PR TITLE
fix(api.service): fix scheme for API URL to https

### DIFF
--- a/src/services/api.service.js
+++ b/src/services/api.service.js
@@ -4,7 +4,7 @@
  * @returns {Promise<any>}
  */
 const getNews = (pageNumber = 1) => {
-  const url = `http://hn.algolia.com/api/v1/search?page=${pageNumber}`;
+  const url = `https://hn.algolia.com/api/v1/search?page=${pageNumber}`;
   return fetch(url)
     .then((res) => res.json())
     .then(({ hits }) => {


### PR DESCRIPTION
Request was failing due to mixed content. Changed the scheme of the API to use `https` instead of `http`.