### PR TITLE
[Issue#3] hide & upvote feature Closes #3

### DIFF
--- a/src/components/NavBar/NavBar.component.scss
+++ b/src/components/NavBar/NavBar.component.scss
@@ -1,6 +1,6 @@
 @import '../../styles/theme';
 
-$color-background: #ef6537;
+$color-background: map-get($palette-primary, 'm0');
 
 .nav-bar {
   width: 100%;

--- a/src/components/NewsCard/NewsCard.component.jsx
+++ b/src/components/NewsCard/NewsCard.component.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { MdThumbUp } from 'react-icons/md';
+import { MdArrowUpward } from 'react-icons/md';
 import Proptypes from 'prop-types';
 
 import NewsItem from '../NewsItem/NewsItem.component';
@@ -45,9 +45,9 @@ const NewsCard = ({
       </section>
       {/* User action for the news */}
       <section className="news-card__actions">
-        <MdThumbUp
+        <MdArrowUpward
+          className="upvote-icon"
           size="24"
-          color="#A6A6A6"
           onClick={() => upvoteHandler(id)}
         />
         <Button clickHandler={() => hideNewsHandler(id)}>Hide</Button>

--- a/src/components/NewsCard/NewsCard.component.scss
+++ b/src/components/NewsCard/NewsCard.component.scss
@@ -2,7 +2,7 @@
 @import '../../styles/theme';
 @import '../../styles/mixins';
 
-$color-border: #ef6537;
+$color-border: map-get($palette-primary, 'm0');
 $color-background: map-get($palette-grey, 'l7');
 $height: 6rem;
 $width-border: $size-8;
@@ -79,6 +79,14 @@ $border-radius: 0.7rem;
 
   &__actions {
     justify-content: flex-end;
+
+    .upvote-icon {
+      color: map-get($palette-grey, 'l3');
+      cursor: pointer;
+      &:active {
+        color: map-get($palette-primary, 'm0');
+      }
+    }
 
     & > *:not(:first-child) {
       margin-left: $size-16;

--- a/src/components/NewsItem/NewsItem.component.jsx
+++ b/src/components/NewsItem/NewsItem.component.jsx
@@ -14,8 +14,10 @@ const NewsItem = ({ caption, value }) => (
 NewsItem.propTypes = {
   caption: PropTypes.string.isRequired,
   value: PropTypes.oneOfType([
+    PropTypes.node,
     PropTypes.arrayOf(PropTypes.node),
     PropTypes.string,
+    PropTypes.number,
   ]).isRequired,
 };
 

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,8 +4,14 @@ import ReactDOM from 'react-dom';
 import App from './App';
 
 import * as serviceWorker from './serviceWorker';
+import { getItem, setItem } from './services/localStorage.service';
 
 import './index.scss';
+
+/* Setup the modified entries if not already set */
+if (getItem('MODIFIED_ENTRIES') === null) {
+  setItem('MODIFIED_ENTRIES', {});
+}
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/pages/News/NewsPage.jsx
+++ b/src/pages/News/NewsPage.jsx
@@ -35,16 +35,13 @@ export default function NewsPage() {
   const onUpvote = (id) => {
     const modifiedNews = news.map((item) => {
       if (item.objectID === id) {
-        return {
-          ...item,
-          points: item.points + 1,
-        };
+        const modifiedItem = { ...item, points: item.points + 1 };
+        updateModifiedEntries(modifiedItem);
+        return modifiedItem;
       }
       return item;
     });
-    const [targetNews] = modifiedNews.filter((item) => item.objectID === id);
     setNews(modifiedNews);
-    updateModifiedEntries(targetNews);
   };
 
   /**

--- a/src/pages/News/NewsPage.jsx
+++ b/src/pages/News/NewsPage.jsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 
 import NewsCard from '../../components/NewsCard/NewsCard.component';
 
-import getNews from '../../services/api.service';
+import { getNews, updateModifiedEntries } from '../../services/api.service';
 
 import './NewsPage.scss';
 
@@ -28,8 +28,46 @@ export default function NewsPage() {
       });
   }, []);
 
-  const onUpvote = (id) => console.log('upvote!', id);
-  const onHideNews = (id) => console.log('hide!', id);
+  /**
+   * This is a callback function which will trigger the upvote action on a card.
+   * @param {*} id - Unique id of the news item
+   */
+  const onUpvote = (id) => {
+    const modifiedNews = news.map((item) => {
+      if (item.objectID === id) {
+        return {
+          ...item,
+          points: item.points + 1,
+        };
+      }
+      return item;
+    });
+    const [targetNews] = modifiedNews.filter((item) => item.objectID === id);
+    setNews(modifiedNews);
+    updateModifiedEntries(targetNews);
+  };
+
+  /**
+   * This is a callback function which will trigger the hide action on a card.
+   * @param {*} id - Unique id of the news item
+   */
+  const onHideNews = (id) => {
+    const modifiedNews = news
+      .map((item) => {
+        if (item.objectID === id) {
+          const modifiedItem = { ...item, hide: true };
+          updateModifiedEntries(modifiedItem);
+          return modifiedItem;
+        }
+        return item;
+      })
+      .filter((item) => !item.hide);
+
+    setNews(modifiedNews);
+    if (!modifiedNews.length) {
+      setNoContent(true);
+    }
+  };
 
   return (
     <div className="news container">
@@ -37,7 +75,7 @@ export default function NewsPage() {
       {noContent && <div className="no-content">No news found!</div>}
       {news.map((item) => (
         <NewsCard
-          key={item.objectId}
+          key={item.objectID}
           news={item}
           upvoteHandler={() => onUpvote(item.objectID)}
           hideNewsHandler={onHideNews}

--- a/src/services/api.service.js
+++ b/src/services/api.service.js
@@ -1,19 +1,50 @@
+import { getItem, setItem } from './localStorage.service';
+
 /**
  * This function will fetch the NEWS provided the page number.
  * @param {*} pageNumber - Page number
  * @returns {Promise<any>}
  */
-const getNews = (pageNumber = 1) => {
+export const getNews = (pageNumber = 1) => {
   const url = `https://hn.algolia.com/api/v1/search?page=${pageNumber}`;
+  const modifiedEntries = getItem('MODIFIED_ENTRIES');
   return fetch(url)
     .then((res) => res.json())
     .then(({ hits }) => {
-      const transformedData = hits.map((hit) => ({
-        ...hit,
-        hide: false,
-      }));
+      const transformedData = hits
+        /* Add additional `hide` property on each item for UI purposes */
+        .map((item) => ({
+          ...item,
+          hide: false,
+        }))
+        /* If the item present in the modified entries, replace the original item with the modified one */
+        .map((item) => {
+          if (modifiedEntries[item.objectID] !== undefined) {
+            return modifiedEntries[item.objectID];
+          }
+          return item;
+        })
+        /* Filter out all the hidden items */
+        .filter((item) => !item.hide);
       return Promise.resolve(transformedData);
     });
 };
 
-export default getNews;
+/**
+ * This function will update the localstorage with the modified entries.
+ * A modified entry will have two cases:
+ * 1. More votes are added
+ * 2. Hidden action is taken
+ *
+ * `MODIFIED_ENTRIES` object will be updated in the localstorage with the new
+ * updated value.
+ * @param {*} modifiedEntry - Modified news item object
+ */
+export const updateModifiedEntries = (modifiedEntry) => {
+  const modifiedEntries = getItem('MODIFIED_ENTRIES');
+  const updatedEntries = {
+    ...modifiedEntries,
+    [modifiedEntry.objectID]: modifiedEntry,
+  };
+  setItem('MODIFIED_ENTRIES', updatedEntries);
+};

--- a/src/services/localStorage.service.js
+++ b/src/services/localStorage.service.js
@@ -1,0 +1,32 @@
+export const setItem = (key, value) => {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch (error) {
+    /* Leaving the catch block */
+  }
+};
+
+export const getItem = (key) => {
+  try {
+    const value = localStorage.getItem(key);
+    return JSON.parse(value);
+  } catch (error) {
+    return undefined;
+  }
+};
+
+export const removeItem = (key) => {
+  try {
+    localStorage.removeItem(key);
+  } catch (error) {
+    /* Leaving the catch block */
+  }
+};
+
+export const clearStorage = () => {
+  try {
+    localStorage.clear();
+  } catch (error) {
+    /* Leaving the catch block */
+  }
+};

--- a/src/styles/_theme.scss
+++ b/src/styles/_theme.scss
@@ -9,3 +9,7 @@ $palette-grey: (
   l6: #f2f2f2,
   l7: #ffffff,
 );
+
+$palette-primary: (
+  m0: #ef6537,
+);


### PR DESCRIPTION
### In this PR

I have added the feature to Hide/Upvote the news.

The hidden news and the added votes will be persistent and the user will always see the filtered state even on page refresh.

For accessing the browser `localstorage` I have create a new `localStorage.service` which exports the functions to interact with the `localstorage`.

I have changed the upvote icon.
![image](https://user-images.githubusercontent.com/13901302/85216665-ee2a9d00-b3a4-11ea-80b1-11df7e581a0c.png)
